### PR TITLE
Adding tqdm as a development dependency

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,3 +18,4 @@ setuptools>=49.6.0
 wheel>=0.35.1
 twine>=3.2.0
 combo==0.1.3
+tqdm==4.67.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,3 +19,4 @@ wheel>=0.35.1
 twine>=3.2.0
 combo==0.1.3
 tqdm==4.67.1
+attrs==25.3.0


### PR DESCRIPTION
When I tested the example scripts with an entirely new environment, the example scripts didn't execute because tqdm was missing. 