### PR TITLE
feat: add Seasonal ESD models

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -123,6 +123,7 @@ Alternatively, you can install the library directly using the source code in Git
 * numpy: 2.1.3
 * scikit-learn: 1.5.2
 * scipy: 1.15.3
+* statsmodels: 0.14.4 (for ``pysad.models.SeasonalESD``, ``pysad.models.SeasonalHybridESD`` and ``pysad.transform.preprocessing.ModifiedSTLResidualTransformer``)
 * pyod: 2.1.0
 * combo: 0.1.3
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -154,6 +154,7 @@ Preprocessors
     transform.preprocessing.IdentityScaler
     transform.preprocessing.InstanceStandardScaler
     transform.preprocessing.InstanceUnitNormScaler
+    transform.preprocessing.SeasonalTrendDecomposer
 
 
 Postprocessors
@@ -250,4 +251,3 @@ Utilities
     utils.get_minmax_array
     utils.get_minmax_scalar
     utils.fix_seed
-

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -55,6 +55,8 @@ Individual Anomaly Models
     models.RelativeEntropy
     models.RobustRandomCutForest
     models.RSHash
+    models.SeasonalESD
+    models.SeasonalHybridESD
     models.StandardAbsoluteDeviation
     models.xStream
 
@@ -154,6 +156,7 @@ Preprocessors
     transform.preprocessing.IdentityScaler
     transform.preprocessing.InstanceStandardScaler
     transform.preprocessing.InstanceUnitNormScaler
+    transform.preprocessing.ModifiedSTLResidualTransformer
     transform.preprocessing.SeasonalTrendDecomposer
 
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -26,6 +26,7 @@ Alternatively, you can install the library directly using the source code in Git
 * numpy: 2.1.3
 * scikit-learn: 1.5.2
 * scipy: 1.15.3
+* statsmodels: 0.14.4 (for ``pysad.models.SeasonalESD``, ``pysad.models.SeasonalHybridESD`` and ``pysad.transform.preprocessing.ModifiedSTLResidualTransformer``)
 * pyod: 2.1.0
 * combo: 0.1.3
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
   "numpy",
   "scikit-learn",
   "scipy",
+  "statsmodels",
   "pyod==2.0.5",
   "combo==0.1.3",
 ]
@@ -56,4 +57,3 @@ Documentation = "https://pysad.readthedocs.io/"
 Repository = "https://github.com/selimfirat/pysad.git"
 "Bug Tracker" = "https://github.com/selimfirat/pysad/issues"
 Changelog = "https://github.com/selimfirat/pysad/blob/master/CHANGES.txt"
-

--- a/pysad/models/__init__.py
+++ b/pysad/models/__init__.py
@@ -14,6 +14,7 @@ from .random_model import RandomModel
 from .relative_entropy import RelativeEntropy
 from .robust_random_cut_forest import RobustRandomCutForest
 from .rs_hash import RSHash
+from .seasonal_esd import SeasonalESD, SeasonalHybridESD
 from .standard_absolute_deviation import StandardAbsoluteDeviation
 from .xstream import xStream
 from .exact_storm import ExactStorm
@@ -26,7 +27,7 @@ except (ImportError, NameError, AttributeError):
     # Handle missing dependencies, undefined names, and JAX-NumPy compatibility issues
     _has_inqmad = False
 
-__all__ = ["ExactStorm", "HalfSpaceTrees", "IForestASD", "KitNet", "KNNCAD", "LODA", "LocalOutlierProbability", "MedianAbsoluteDeviation", "NullModel", "PerfectModel", "RandomModel", "RelativeEntropy", "RobustRandomCutForest", "RSHash", "StandardAbsoluteDeviation", "xStream"]
+__all__ = ["ExactStorm", "HalfSpaceTrees", "IForestASD", "KitNet", "KNNCAD", "LODA", "LocalOutlierProbability", "MedianAbsoluteDeviation", "NullModel", "PerfectModel", "RandomModel", "RelativeEntropy", "RobustRandomCutForest", "RSHash", "SeasonalESD", "SeasonalHybridESD", "StandardAbsoluteDeviation", "xStream"]
 
 # Add Inqmad to __all__ if available
 if _has_inqmad:

--- a/pysad/models/median_absolute_deviation.py
+++ b/pysad/models/median_absolute_deviation.py
@@ -5,6 +5,11 @@ from pysad.statistics.median_meter import MedianMeter
 class MedianAbsoluteDeviation(BaseModel):
     """Median Absolute Deviation method :cite:`hochenbaum2017automatic`.
 
+    This model only performs streaming univariate statistical scoring. It does
+    not apply STL decomposition, detrending, or deseasonalization internally;
+    preprocess seasonal or trending series before fitting/scoring, for example
+    with :class:`pysad.transform.preprocessing.SeasonalTrendDecomposer`.
+
     Args:
         absolute (bool): Whether to output score's absolute value (Default=True).
         b (float): The default value `1.4826` is used for normally distributed data. See :cite:`hochenbaum2017automatic` for details. (Default=1.4826).

--- a/pysad/models/median_absolute_deviation.py
+++ b/pysad/models/median_absolute_deviation.py
@@ -5,10 +5,10 @@ from pysad.statistics.median_meter import MedianMeter
 class MedianAbsoluteDeviation(BaseModel):
     """Median Absolute Deviation method :cite:`hochenbaum2017automatic`.
 
-    This model only performs streaming univariate statistical scoring. It does
-    not apply STL decomposition, detrending, or deseasonalization internally;
-    preprocess seasonal or trending series before fitting/scoring, for example
-    with :class:`pysad.transform.preprocessing.SeasonalTrendDecomposer`.
+    This is a streaming MAD score component, not the paper's S-H-ESD method.
+    It does not apply STL decomposition or generalized ESD internally. Use
+    :class:`pysad.models.SeasonalHybridESD` for the paper's modified-STL plus
+    median/MAD ESD detector.
 
     Args:
         absolute (bool): Whether to output score's absolute value (Default=True).

--- a/pysad/models/seasonal_esd.py
+++ b/pysad/models/seasonal_esd.py
@@ -65,13 +65,13 @@ class SeasonalESD(BaseModel):
 
     def _candidate_window(self, X):
         value = self._as_value(X)
-        values = self.window.get()
-
-        if len(values) == 0 or not np.array_equal(np.asarray(values[-1]), value):
-            values = values + [value]
-            values = values[-self.window_size:]
+        values = self.window.get() + [value]
+        values = values[-self.window_size:]
 
         return np.asarray(values, dtype=np.float64)
+
+    def _current_window(self):
+        return np.asarray(self.window.get(), dtype=np.float64)
 
     def _critical_value(self, n, i):
         p = 1.0 - self.alpha / (2.0 * (n - i + 1))
@@ -110,10 +110,7 @@ class SeasonalESD(BaseModel):
         self.window.update(self._as_value(X))
         return self
 
-    def score_partial(self, X):
-        """Scores whether the latest instance is anomalous in the current window."""
-        values = self._candidate_window(X)
-
+    def _score_window(self, values):
         if values.shape[0] < self.window_size:
             return 0.0
 
@@ -126,6 +123,15 @@ class SeasonalESD(BaseModel):
                 return statistic
 
         return 0.0
+
+    def score_partial(self, X):
+        """Scores whether the next instance is anomalous in a candidate window."""
+        return self._score_window(self._candidate_window(X))
+
+    def fit_score_partial(self, X, y=None):
+        """Adds and scores the next instance without adding it twice."""
+        self.fit_partial(X, y)
+        return self._score_window(self._current_window())
 
 
 class SeasonalHybridESD(SeasonalESD):

--- a/pysad/models/seasonal_esd.py
+++ b/pysad/models/seasonal_esd.py
@@ -1,0 +1,138 @@
+import numpy as np
+from scipy.stats import t
+
+from pysad.core.base_model import BaseModel
+from pysad.transform.preprocessing import ModifiedSTLResidualTransformer
+from pysad.utils import Window
+
+
+class SeasonalESD(BaseModel):
+    """Window-based Seasonal ESD model :cite:`hochenbaum2017automatic`.
+
+    This model computes the modified STL residual over a fixed-size PySAD
+    window, applies generalized ESD to the residuals, and scores the latest
+    observation when it is selected as anomalous.
+
+    Args:
+        period (int): Number of observations in one seasonal period.
+        window_size (int): Number of recent observations used for STL and ESD.
+        max_anomalies (int): Maximum number of anomalies tested by ESD.
+        alpha (float): ESD significance level. (Default=0.05).
+        robust (bool): Whether to use robust STL fitting. (Default=True).
+        **stl_kwargs: Additional keyword arguments passed to STL.
+    """
+
+    def __init__(
+            self,
+            period,
+            window_size,
+            max_anomalies,
+            alpha=0.05,
+            robust=True,
+            **stl_kwargs):
+        if max_anomalies < 1:
+            raise ValueError("max_anomalies must be greater than 0.")
+
+        if max_anomalies > int(window_size * 0.49):
+            raise ValueError(
+                "max_anomalies must be less than or equal to window_size * 0.49.")
+
+        self.period = period
+        self.window_size = window_size
+        self.max_anomalies = max_anomalies
+        self.alpha = alpha
+        self.window = Window(window_size)
+        self.residual_transformer = ModifiedSTLResidualTransformer(
+            period=period,
+            window_size=window_size,
+            robust=robust,
+            **stl_kwargs
+        )
+
+    def _as_value(self, X):
+        X = np.asarray(X, dtype=np.float64)
+
+        if X.shape != (1,):
+            raise ValueError("SeasonalESD supports univariate inputs.")
+
+        return X[0]
+
+    def _center_scale(self, values):
+        return np.mean(values), np.std(values, ddof=1)
+
+    def _candidate_window(self, X):
+        value = self._as_value(X)
+        values = self.window.get()
+
+        if len(values) == 0 or not np.array_equal(np.asarray(values[-1]), value):
+            values = values + [value]
+            values = values[-self.window_size:]
+
+        return np.asarray(values, dtype=np.float64)
+
+    def _critical_value(self, n, i):
+        p = 1.0 - self.alpha / (2.0 * (n - i + 1))
+        t_value = t.ppf(p, n - i - 1)
+        return ((n - i) * t_value) / np.sqrt((n - i - 1 + t_value**2) * (n - i + 1))
+
+    def _esd(self, values):
+        remaining_values = np.asarray(values, dtype=np.float64)
+        remaining_indices = np.arange(remaining_values.shape[0])
+        candidates = []
+
+        for i in range(1, self.max_anomalies + 1):
+            center, scale = self._center_scale(remaining_values)
+            if scale <= 1e-10:
+                break
+
+            deviations = np.abs(remaining_values - center) / scale
+            local_idx = int(np.argmax(deviations))
+            candidates.append((
+                remaining_indices[local_idx],
+                deviations[local_idx],
+                self._critical_value(values.shape[0], i)
+            ))
+            remaining_values = np.delete(remaining_values, local_idx)
+            remaining_indices = np.delete(remaining_indices, local_idx)
+
+        selected_count = 0
+        for i, (_, statistic, critical_value) in enumerate(candidates, start=1):
+            if statistic > critical_value:
+                selected_count = i
+
+        return candidates[:selected_count]
+
+    def fit_partial(self, X, y=None):
+        """Adds the next instance to the model window."""
+        self.window.update(self._as_value(X))
+        return self
+
+    def score_partial(self, X):
+        """Scores whether the latest instance is anomalous in the current window."""
+        values = self._candidate_window(X)
+
+        if values.shape[0] < self.window_size:
+            return 0.0
+
+        residuals = self.residual_transformer.transform_window(values)
+        anomalies = self._esd(residuals)
+        latest_idx = values.shape[0] - 1
+
+        for idx, statistic, _ in anomalies:
+            if idx == latest_idx:
+                return statistic
+
+        return 0.0
+
+
+class SeasonalHybridESD(SeasonalESD):
+    """Window-based Seasonal Hybrid ESD model :cite:`hochenbaum2017automatic`.
+
+    This model follows Seasonal ESD's modified STL residual step, but uses the
+    robust median and MAD-based scale in the ESD statistic.
+    """
+
+    def _center_scale(self, values):
+        center = np.median(values)
+        scale = 1.4826 * np.median(np.abs(values - center))
+        return center, scale

--- a/pysad/models/seasonal_esd.py
+++ b/pysad/models/seasonal_esd.py
@@ -33,6 +33,9 @@ class SeasonalESD(BaseModel):
         if max_anomalies < 1:
             raise ValueError("max_anomalies must be greater than 0.")
 
+        if window_size < 2 * period:
+            raise ValueError("window_size must be at least 2 * period.")
+
         if max_anomalies > int(window_size * 0.49):
             raise ValueError(
                 "max_anomalies must be less than or equal to window_size * 0.49.")

--- a/pysad/models/seasonal_esd.py
+++ b/pysad/models/seasonal_esd.py
@@ -9,9 +9,9 @@ from pysad.utils import Window
 class SeasonalESD(BaseModel):
     """Window-based Seasonal ESD model :cite:`hochenbaum2017automatic`.
 
-    This model computes the modified STL residual over a fixed-size PySAD
-    window, applies generalized ESD to the residuals, and scores the latest
-    observation when it is selected as anomalous.
+    This is the paper's S-ESD method: compute the modified STL residual
+    ``X - seasonal - median(X)`` over a fixed-size PySAD window, then apply
+    generalized ESD with mean and standard deviation to the residuals.
 
     Args:
         period (int): Number of observations in one seasonal period.
@@ -128,8 +128,9 @@ class SeasonalESD(BaseModel):
 class SeasonalHybridESD(SeasonalESD):
     """Window-based Seasonal Hybrid ESD model :cite:`hochenbaum2017automatic`.
 
-    This model follows Seasonal ESD's modified STL residual step, but uses the
-    robust median and MAD-based scale in the ESD statistic.
+    This is the paper's S-H-ESD method: use the same modified STL residual as
+    :class:`SeasonalESD`, then replace ESD's mean and standard deviation with
+    median and MAD-based scale in the test statistic.
     """
 
     def _center_scale(self, values):

--- a/pysad/models/standard_absolute_deviation.py
+++ b/pysad/models/standard_absolute_deviation.py
@@ -7,11 +7,10 @@ from pysad.statistics.variance_meter import VarianceMeter
 class StandardAbsoluteDeviation(BaseModel):
     """The model that assigns the deviation from the mean (or median) and divides with the standard deviation. This model is based on the 3-Sigma rule described in :cite:`hochenbaum2017automatic`.
 
-        This model only performs streaming univariate statistical scoring. It
-        does not apply STL decomposition, detrending, or deseasonalization
-        internally; preprocess seasonal or trending series before
-        fitting/scoring, for example with
-        :class:`pysad.transform.preprocessing.SeasonalTrendDecomposer`.
+        This is a streaming standard-deviation score component, not the paper's
+        S-ESD method. It does not apply STL decomposition or generalized ESD
+        internally. Use :class:`pysad.models.SeasonalESD` for the paper's
+        modified-STL plus standard ESD detector.
 
         substracted_statistic (str): The statistic to be substracted for scoring. It is either "mean" or "median". (Default="mean").
         absolute (bool): Whether to output score's absolute value. (Default=True).

--- a/pysad/models/standard_absolute_deviation.py
+++ b/pysad/models/standard_absolute_deviation.py
@@ -7,6 +7,12 @@ from pysad.statistics.variance_meter import VarianceMeter
 class StandardAbsoluteDeviation(BaseModel):
     """The model that assigns the deviation from the mean (or median) and divides with the standard deviation. This model is based on the 3-Sigma rule described in :cite:`hochenbaum2017automatic`.
 
+        This model only performs streaming univariate statistical scoring. It
+        does not apply STL decomposition, detrending, or deseasonalization
+        internally; preprocess seasonal or trending series before
+        fitting/scoring, for example with
+        :class:`pysad.transform.preprocessing.SeasonalTrendDecomposer`.
+
         substracted_statistic (str): The statistic to be substracted for scoring. It is either "mean" or "median". (Default="mean").
         absolute (bool): Whether to output score's absolute value. (Default=True).
     """

--- a/pysad/transform/preprocessing/__init__.py
+++ b/pysad/transform/preprocessing/__init__.py
@@ -4,11 +4,13 @@ The :mod:`pysad.transform.preprocessing` module includes preprocessing methods t
 from .identity_scaler import IdentityScaler
 from .instance_standard_scaler import InstanceStandardScaler
 from .instance_unit_norm_scaler import InstanceUnitNormScaler
+from .modified_stl_residual import ModifiedSTLResidualTransformer
 from .seasonal_trend_decomposer import SeasonalTrendDecomposer
 
 __all__ = [
     "IdentityScaler",
     "InstanceStandardScaler",
     "InstanceUnitNormScaler",
+    "ModifiedSTLResidualTransformer",
     "SeasonalTrendDecomposer",
 ]

--- a/pysad/transform/preprocessing/__init__.py
+++ b/pysad/transform/preprocessing/__init__.py
@@ -4,5 +4,11 @@ The :mod:`pysad.transform.preprocessing` module includes preprocessing methods t
 from .identity_scaler import IdentityScaler
 from .instance_standard_scaler import InstanceStandardScaler
 from .instance_unit_norm_scaler import InstanceUnitNormScaler
+from .seasonal_trend_decomposer import SeasonalTrendDecomposer
 
-__all__ = ["IdentityScaler", "InstanceStandardScaler", "InstanceUnitNormScaler"]
+__all__ = [
+    "IdentityScaler",
+    "InstanceStandardScaler",
+    "InstanceUnitNormScaler",
+    "SeasonalTrendDecomposer",
+]

--- a/pysad/transform/preprocessing/modified_stl_residual.py
+++ b/pysad/transform/preprocessing/modified_stl_residual.py
@@ -38,7 +38,14 @@ class ModifiedSTLResidualTransformer(BaseTransformer):
         self.stl_kwargs = stl_kwargs
         self.window = Window(window_size) if window_size is not None else None
 
+    def _normalize_input(self, X):
+        if isinstance(X, tuple):
+            X = X[0]
+
+        return X
+
     def _as_univariate(self, X):
+        X = self._normalize_input(X)
         X = np.asarray(X, dtype=np.float64)
 
         if X.ndim == 2 and X.shape[1] == 1:

--- a/pysad/transform/preprocessing/modified_stl_residual.py
+++ b/pysad/transform/preprocessing/modified_stl_residual.py
@@ -109,6 +109,9 @@ class ModifiedSTLResidualTransformer(BaseTransformer):
         return np.asarray(values, dtype=np.float64)
 
     def _latest_residual(self, values):
+        if values.shape[0] < 2 * self.period:
+            return 0.0
+
         residuals = self.transform_window(values)
         return residuals[-1]
 

--- a/pysad/transform/preprocessing/modified_stl_residual.py
+++ b/pysad/transform/preprocessing/modified_stl_residual.py
@@ -1,0 +1,101 @@
+import numpy as np
+
+from pysad.core.base_transformer import BaseTransformer
+from pysad.utils import Window
+
+
+class ModifiedSTLResidualTransformer(BaseTransformer):
+    """Modified STL residual transformer used by Seasonal ESD.
+
+    The transformer follows the residual construction in
+    :cite:`hochenbaum2017automatic`: estimate the seasonal component with STL,
+    replace STL's trend component with the median of the raw series, and return
+    ``X - seasonal - median(X)``.
+
+    Args:
+        period (int): Number of observations in one seasonal period.
+        window_size (int): Number of recent observations used for partial
+            transforms.
+        robust (bool): Whether to use robust STL fitting. (Default=True).
+        **stl_kwargs: Additional keyword arguments passed to
+            ``statsmodels.tsa.seasonal.STL``.
+    """
+
+    def __init__(self, period, window_size=None, robust=True, **stl_kwargs):
+        super().__init__(-1)
+
+        if period < 2:
+            raise ValueError("period must be greater than 1.")
+
+        if window_size is not None and window_size < 2 * period:
+            raise ValueError("window_size must be at least 2 * period.")
+
+        self.period = period
+        self.window_size = window_size
+        self.robust = robust
+        self.stl_kwargs = stl_kwargs
+        self.window = Window(window_size) if window_size is not None else None
+
+    def _as_univariate(self, X):
+        X = np.asarray(X, dtype=np.float64)
+
+        if X.ndim == 2 and X.shape[1] == 1:
+            X = X.ravel()
+        elif X.ndim != 1:
+            raise ValueError("ModifiedSTLResidualTransformer supports univariate inputs.")
+
+        return X
+
+    def transform_window(self, X):
+        """Transforms a full window into modified STL residuals.
+
+        Args:
+            X (np.float64 array of shape (num_instances,) or
+                (num_instances, 1)): Window of univariate values.
+
+        Returns:
+            residual_X (np.float64 array of shape (num_instances,)): Modified STL residuals.
+        """
+        from statsmodels.tsa.seasonal import STL
+
+        X = self._as_univariate(X)
+
+        if X.shape[0] < 2 * self.period:
+            raise ValueError("At least 2 * period observations are required for STL.")
+
+        seasonal = STL(
+            X,
+            period=self.period,
+            robust=self.robust,
+            **self.stl_kwargs
+        ).fit().seasonal
+        return X - seasonal - np.median(X)
+
+    def fit_partial(self, X):
+        """Fits the next timestep by adding it to the residual window."""
+        if self.window is None:
+            raise ValueError("window_size is required for partial fitting.")
+
+        X = self._as_univariate(X)
+        if X.shape[0] != 1:
+            raise ValueError("Partial fitting requires a single univariate value.")
+
+        self.window.update(X[0])
+        return self
+
+    def transform_partial(self, X):
+        """Returns the latest residual for the current candidate window."""
+        if self.window is None:
+            raise ValueError("window_size is required for partial transforms.")
+
+        X = self._as_univariate(X)
+        if X.shape[0] != 1:
+            raise ValueError("Partial transforms require a single univariate value.")
+
+        values = self.window.get()
+        if len(values) == 0 or not np.array_equal(np.asarray(values[-1]), X[0]):
+            values = values + [X[0]]
+            values = values[-self.window_size:]
+
+        residuals = self.transform_window(values)
+        return residuals[-1]

--- a/pysad/transform/preprocessing/modified_stl_residual.py
+++ b/pysad/transform/preprocessing/modified_stl_residual.py
@@ -5,12 +5,14 @@ from pysad.utils import Window
 
 
 class ModifiedSTLResidualTransformer(BaseTransformer):
-    """Modified STL residual transformer used by Seasonal ESD.
+    """Modified STL residual transformer used by S-ESD and S-H-ESD.
 
     The transformer follows the residual construction in
     :cite:`hochenbaum2017automatic`: estimate the seasonal component with STL,
     replace STL's trend component with the median of the raw series, and return
-    ``X - seasonal - median(X)``.
+    ``X - seasonal - median(X)``. It owns only the paper's residual step; use
+    :class:`pysad.models.SeasonalESD` or
+    :class:`pysad.models.SeasonalHybridESD` for the full detector.
 
     Args:
         period (int): Number of observations in one seasonal period.

--- a/pysad/transform/preprocessing/modified_stl_residual.py
+++ b/pysad/transform/preprocessing/modified_stl_residual.py
@@ -92,19 +92,34 @@ class ModifiedSTLResidualTransformer(BaseTransformer):
         self.window.update(X[0])
         return self
 
+    def _as_partial_value(self, X):
+        X = self._as_univariate(X)
+        if X.shape[0] != 1:
+            raise ValueError("Partial operations require a single univariate value.")
+
+        return X[0]
+
+    def _current_values(self):
+        return np.asarray(self.window.get(), dtype=np.float64)
+
+    def _candidate_values(self, X):
+        value = self._as_partial_value(X)
+        values = self.window.get() + [value]
+        values = values[-self.window_size:]
+        return np.asarray(values, dtype=np.float64)
+
+    def _latest_residual(self, values):
+        residuals = self.transform_window(values)
+        return residuals[-1]
+
     def transform_partial(self, X):
-        """Returns the latest residual for the current candidate window."""
+        """Returns the latest residual for the next candidate window."""
         if self.window is None:
             raise ValueError("window_size is required for partial transforms.")
 
-        X = self._as_univariate(X)
-        if X.shape[0] != 1:
-            raise ValueError("Partial transforms require a single univariate value.")
+        return self._latest_residual(self._candidate_values(X))
 
-        values = self.window.get()
-        if len(values) == 0 or not np.array_equal(np.asarray(values[-1]), X[0]):
-            values = values + [X[0]]
-            values = values[-self.window_size:]
-
-        residuals = self.transform_window(values)
-        return residuals[-1]
+    def fit_transform_partial(self, X):
+        """Adds and transforms the next timestep without adding it twice."""
+        self.fit_partial(X)
+        return self._latest_residual(self._current_values())

--- a/pysad/transform/preprocessing/seasonal_trend_decomposer.py
+++ b/pysad/transform/preprocessing/seasonal_trend_decomposer.py
@@ -1,0 +1,130 @@
+from collections import deque
+
+import numpy as np
+
+from pysad.core.base_transformer import BaseTransformer
+
+
+class SeasonalTrendDecomposer(BaseTransformer):
+    """Streaming seasonal and trend decomposition preprocessor.
+
+    The transformer subtracts a rolling mean trend estimate and a running
+    average seasonal estimate for each position in the season. This is an
+    online approximation intended for preprocessing before univariate anomaly
+    scoring; it is not an STL implementation.
+
+    Args:
+        season_length (int): Number of observations in one seasonal period.
+        trend_window (int): Number of recent observations used to estimate the
+            trend. If None, defaults to ``season_length``.
+    """
+
+    def __init__(self, season_length, trend_window=None):
+        super().__init__(-1)
+
+        if season_length < 1:
+            raise ValueError("season_length must be greater than 0.")
+
+        if trend_window is None:
+            trend_window = season_length
+        elif trend_window < 1:
+            raise ValueError("trend_window must be greater than 0.")
+
+        self.season_length = season_length
+        self.trend_window = trend_window
+        self.window = deque(maxlen=trend_window)
+        self.seasonal_sums = None
+        self.seasonal_counts = None
+        self.num_seen = 0
+
+    def _as_array(self, X):
+        if isinstance(X, tuple):
+            X = X[0]
+
+        return np.asarray(X)
+
+    def _init_seasonal_state(self, X):
+        self.seasonal_sums = np.zeros((self.season_length, X.shape[0]))
+        self.seasonal_counts = np.zeros(self.season_length)
+
+    def _trend(self):
+        if len(self.window) == 0:
+            return 0.0
+
+        return np.mean(np.asarray(self.window), axis=0)
+
+    def _seasonal(self, phase):
+        if self.seasonal_counts[phase] == 0:
+            return 0.0
+
+        return self.seasonal_sums[phase] / self.seasonal_counts[phase]
+
+    def fit_partial(self, X):
+        """Fits the next timestep's values to train the decomposer.
+
+        Args:
+            X (np.float64 array of shape (num_features,)): Input feature vector.
+
+        Returns:
+            object: self.
+        """
+        X = self._as_array(X)
+
+        if self.seasonal_sums is None:
+            self._init_seasonal_state(X)
+
+        phase = self.num_seen % self.season_length
+        self.window.append(X)
+        trend = self._trend()
+
+        if len(self.window) == self.trend_window:
+            self.seasonal_sums[phase] += X - trend
+            self.seasonal_counts[phase] += 1
+
+        self.num_seen += 1
+
+        return self
+
+    def transform_partial(self, X):
+        """Transforms the next timestep by removing trend and seasonality.
+
+        Args:
+            X (np.float64 array of shape (num_features,)): Input feature vector.
+
+        Returns:
+            residual_X (np.float64 array of shape (num_features,)): Residual feature vector.
+        """
+        X = self._as_array(X)
+
+        if self.seasonal_sums is None:
+            self._init_seasonal_state(X)
+
+        phase = self.num_seen % self.season_length
+        return X - self._trend() - self._seasonal(phase)
+
+    def fit_transform_partial(self, X):
+        """Fits and transforms the next timestep.
+
+        Args:
+            X (np.float64 array of shape (num_features,)): Input feature vector.
+
+        Returns:
+            residual_X (np.float64 array of shape (num_features,)): Residual feature vector.
+        """
+        X = self._as_array(X)
+
+        if self.seasonal_sums is None:
+            self._init_seasonal_state(X)
+
+        phase = self.num_seen % self.season_length
+        self.window.append(X)
+        trend = self._trend()
+
+        if len(self.window) == self.trend_window:
+            self.seasonal_sums[phase] += X - trend
+            self.seasonal_counts[phase] += 1
+
+        seasonal = self._seasonal(phase)
+        self.num_seen += 1
+
+        return X - trend - seasonal

--- a/pysad/transform/preprocessing/seasonal_trend_decomposer.py
+++ b/pysad/transform/preprocessing/seasonal_trend_decomposer.py
@@ -11,7 +11,9 @@ class SeasonalTrendDecomposer(BaseTransformer):
     The transformer subtracts a rolling mean trend estimate and a running
     average seasonal estimate for each position in the season. This is an
     online approximation intended for preprocessing before univariate anomaly
-    scoring; it is not an STL implementation.
+    scoring; it is not an STL implementation and does not reproduce the
+    modified STL residual used by Seasonal ESD in
+    :cite:`hochenbaum2017automatic`.
 
     Args:
         season_length (int): Number of observations in one seasonal period.

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,6 +1,7 @@
 numpy==2.1.3
 scikit-learn==1.5.2
 scipy==1.15.3
+statsmodels==0.14.4
 pyod==2.0.5
 pandas==2.2.3
 rrcf==0.4.4

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,6 +9,7 @@ sphinxcontrib-bibtex==2.6.3
 numpy==2.1.3
 pandas==2.2.3
 scipy==1.15.3
+statsmodels==0.14.4
 pyod==2.0.5
 rrcf==0.4.4
 PyNomaly==0.3.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 numpy==2.1.3
 scikit-learn==1.5.2
 scipy==1.15.3
+statsmodels==0.14.4
 pyod==2.1.0
 combo==0.1.3

--- a/tests/models/test_seasonal_esd.py
+++ b/tests/models/test_seasonal_esd.py
@@ -1,0 +1,64 @@
+
+def test_seasonal_esd_detects_latest_window_anomaly(monkeypatch):
+    import numpy as np
+    from pysad.models import SeasonalESD
+
+    monkeypatch.setattr(
+        "pysad.models.seasonal_esd.ModifiedSTLResidualTransformer.transform_window",
+        lambda self, values: np.asarray(values, dtype=float),
+    )
+
+    X = np.array([[0.0], [0.1], [-0.1], [0.0], [8.0]])
+    model = SeasonalESD(period=2, window_size=5, max_anomalies=1)
+    scores = model.fit_score(X)
+
+    assert scores[-1] > 0.0
+
+
+def test_seasonal_hybrid_esd_detects_latest_window_anomaly(monkeypatch):
+    import numpy as np
+    from pysad.models import SeasonalHybridESD
+
+    monkeypatch.setattr(
+        "pysad.models.seasonal_esd.ModifiedSTLResidualTransformer.transform_window",
+        lambda self, values: np.asarray(values, dtype=float),
+    )
+
+    X = np.array([[0.0], [0.1], [-0.1], [0.0], [8.0]])
+    model = SeasonalHybridESD(period=2, window_size=5, max_anomalies=1)
+    scores = model.fit_score(X)
+
+    assert scores[-1] > 0.0
+
+
+def test_seasonal_esd_uses_window_for_latest_candidate(monkeypatch):
+    import numpy as np
+    from pysad.models import SeasonalESD
+
+    seen_window_sizes = []
+
+    def fake_transform(self, values):
+        seen_window_sizes.append(len(values))
+        return np.asarray(values, dtype=float)
+
+    monkeypatch.setattr(
+        "pysad.models.seasonal_esd.ModifiedSTLResidualTransformer.transform_window",
+        fake_transform,
+    )
+
+    model = SeasonalESD(period=2, window_size=5, max_anomalies=1)
+    model.fit(np.array([[0.0], [0.1], [-0.1], [0.0]]))
+    model.score_partial(np.array([8.0]))
+
+    assert seen_window_sizes == [5]
+
+
+def test_seasonal_esd_validates_configuration():
+    from numpy.testing import assert_raises
+    from pysad.models import SeasonalESD
+
+    with assert_raises(ValueError):
+        SeasonalESD(period=2, window_size=5, max_anomalies=0)
+
+    with assert_raises(ValueError):
+        SeasonalESD(period=2, window_size=5, max_anomalies=3)

--- a/tests/models/test_seasonal_esd.py
+++ b/tests/models/test_seasonal_esd.py
@@ -62,3 +62,11 @@ def test_seasonal_esd_validates_configuration():
 
     with assert_raises(ValueError):
         SeasonalESD(period=2, window_size=5, max_anomalies=3)
+
+
+def test_seasonal_esd_rejects_short_windows():
+    from numpy.testing import assert_raises
+    from pysad.models import SeasonalESD
+
+    with assert_raises(ValueError):
+        SeasonalESD(period=10, window_size=15, max_anomalies=1)

--- a/tests/models/test_seasonal_esd.py
+++ b/tests/models/test_seasonal_esd.py
@@ -53,6 +53,50 @@ def test_seasonal_esd_uses_window_for_latest_candidate(monkeypatch):
     assert seen_window_sizes == [5]
 
 
+def test_seasonal_esd_scores_repeated_latest_candidate(monkeypatch):
+    import numpy as np
+    from pysad.models import SeasonalESD
+
+    seen_windows = []
+
+    def fake_transform(self, values):
+        seen_windows.append(np.asarray(values, dtype=float).copy())
+        return np.asarray(values, dtype=float)
+
+    monkeypatch.setattr(
+        "pysad.models.seasonal_esd.ModifiedSTLResidualTransformer.transform_window",
+        fake_transform,
+    )
+
+    model = SeasonalESD(period=2, window_size=5, max_anomalies=1)
+    model.fit(np.array([[0.0], [1.0], [2.0], [3.0]]))
+    model.score_partial(np.array([3.0]))
+
+    assert np.array_equal(seen_windows[0], np.array([0.0, 1.0, 2.0, 3.0, 3.0]))
+
+
+def test_seasonal_esd_fit_score_does_not_double_append(monkeypatch):
+    import numpy as np
+    from pysad.models import SeasonalESD
+
+    seen_windows = []
+
+    def fake_transform(self, values):
+        seen_windows.append(np.asarray(values, dtype=float).copy())
+        return np.asarray(values, dtype=float)
+
+    monkeypatch.setattr(
+        "pysad.models.seasonal_esd.ModifiedSTLResidualTransformer.transform_window",
+        fake_transform,
+    )
+
+    model = SeasonalESD(period=2, window_size=5, max_anomalies=1)
+    model.fit(np.array([[0.0], [1.0], [2.0], [3.0]]))
+    model.fit_score_partial(np.array([3.0]))
+
+    assert np.array_equal(seen_windows[0], np.array([0.0, 1.0, 2.0, 3.0, 3.0]))
+
+
 def test_seasonal_esd_validates_configuration():
     from numpy.testing import assert_raises
     from pysad.models import SeasonalESD

--- a/tests/transform/preprocessing/test_modified_stl_residual.py
+++ b/tests/transform/preprocessing/test_modified_stl_residual.py
@@ -43,3 +43,33 @@ def test_modified_stl_residual_validates_inputs():
 
     with assert_raises(ValueError):
         ModifiedSTLResidualTransformer(period=3, window_size=5)
+
+
+def test_modified_stl_residual_fit_handles_base_transformer_tuple(monkeypatch):
+    import numpy as np
+    import sys
+    import types
+    from pysad.transform.preprocessing import ModifiedSTLResidualTransformer
+
+    class DummySTL:
+        def __init__(self, X, period, robust, **kwargs):
+            self.X = X
+
+        def fit(self):
+            class Result:
+                seasonal = np.zeros(4)
+
+            return Result()
+
+    statsmodels_module = types.ModuleType("statsmodels")
+    tsa_module = types.ModuleType("statsmodels.tsa")
+    seasonal_module = types.ModuleType("statsmodels.tsa.seasonal")
+    seasonal_module.STL = DummySTL
+    monkeypatch.setitem(sys.modules, "statsmodels", statsmodels_module)
+    monkeypatch.setitem(sys.modules, "statsmodels.tsa", tsa_module)
+    monkeypatch.setitem(sys.modules, "statsmodels.tsa.seasonal", seasonal_module)
+
+    transformer = ModifiedSTLResidualTransformer(period=2, window_size=4)
+    transformer.fit(np.array([[1.0], [2.0], [3.0], [4.0]]))
+
+    assert transformer.window.get() == [1.0, 2.0, 3.0, 4.0]

--- a/tests/transform/preprocessing/test_modified_stl_residual.py
+++ b/tests/transform/preprocessing/test_modified_stl_residual.py
@@ -1,0 +1,45 @@
+
+def test_modified_stl_residual_transformer_uses_paper_residual(monkeypatch):
+    import numpy as np
+    import sys
+    import types
+    from pysad.transform.preprocessing import ModifiedSTLResidualTransformer
+
+    class DummySTL:
+        def __init__(self, X, period, robust, **kwargs):
+            self.X = X
+            self.period = period
+            self.robust = robust
+            self.kwargs = kwargs
+
+        def fit(self):
+            class Result:
+                seasonal = np.array([0.0, 1.0, 0.0, 1.0])
+
+            return Result()
+
+    statsmodels_module = types.ModuleType("statsmodels")
+    tsa_module = types.ModuleType("statsmodels.tsa")
+    seasonal_module = types.ModuleType("statsmodels.tsa.seasonal")
+    seasonal_module.STL = DummySTL
+    monkeypatch.setitem(sys.modules, "statsmodels", statsmodels_module)
+    monkeypatch.setitem(sys.modules, "statsmodels.tsa", tsa_module)
+    monkeypatch.setitem(sys.modules, "statsmodels.tsa.seasonal", seasonal_module)
+
+    X = np.array([10.0, 12.0, 14.0, 16.0])
+    transformer = ModifiedSTLResidualTransformer(period=2)
+
+    residuals = transformer.transform_window(X)
+
+    assert np.all(np.isclose(residuals, X - np.array([0.0, 1.0, 0.0, 1.0]) - np.median(X)))
+
+
+def test_modified_stl_residual_validates_inputs():
+    from numpy.testing import assert_raises
+    from pysad.transform.preprocessing import ModifiedSTLResidualTransformer
+
+    with assert_raises(ValueError):
+        ModifiedSTLResidualTransformer(period=1)
+
+    with assert_raises(ValueError):
+        ModifiedSTLResidualTransformer(period=3, window_size=5)

--- a/tests/transform/preprocessing/test_modified_stl_residual.py
+++ b/tests/transform/preprocessing/test_modified_stl_residual.py
@@ -73,3 +73,51 @@ def test_modified_stl_residual_fit_handles_base_transformer_tuple(monkeypatch):
     transformer.fit(np.array([[1.0], [2.0], [3.0], [4.0]]))
 
     assert transformer.window.get() == [1.0, 2.0, 3.0, 4.0]
+
+
+def test_modified_stl_residual_transform_partial_includes_repeated_candidate(monkeypatch):
+    import numpy as np
+    from pysad.transform.preprocessing import ModifiedSTLResidualTransformer
+
+    seen_windows = []
+
+    def fake_transform_window(self, X):
+        seen_windows.append(np.asarray(X, dtype=float).copy())
+        return np.asarray(X, dtype=float)
+
+    monkeypatch.setattr(
+        "pysad.transform.preprocessing.modified_stl_residual."
+        "ModifiedSTLResidualTransformer.transform_window",
+        fake_transform_window,
+    )
+
+    transformer = ModifiedSTLResidualTransformer(period=2, window_size=4)
+    transformer.fit(np.array([[1.0], [2.0], [3.0]]))
+    residual = transformer.transform_partial(np.array([3.0]))
+
+    assert residual == 3.0
+    assert np.array_equal(seen_windows[0], np.array([1.0, 2.0, 3.0, 3.0]))
+
+
+def test_modified_stl_residual_fit_transform_partial_does_not_double_append(monkeypatch):
+    import numpy as np
+    from pysad.transform.preprocessing import ModifiedSTLResidualTransformer
+
+    seen_windows = []
+
+    def fake_transform_window(self, X):
+        seen_windows.append(np.asarray(X, dtype=float).copy())
+        return np.asarray(X, dtype=float)
+
+    monkeypatch.setattr(
+        "pysad.transform.preprocessing.modified_stl_residual."
+        "ModifiedSTLResidualTransformer.transform_window",
+        fake_transform_window,
+    )
+
+    transformer = ModifiedSTLResidualTransformer(period=2, window_size=4)
+    transformer.fit(np.array([[1.0], [2.0], [3.0]]))
+    residual = transformer.fit_transform_partial(np.array([3.0]))
+
+    assert residual == 3.0
+    assert np.array_equal(seen_windows[0], np.array([1.0, 2.0, 3.0, 3.0]))

--- a/tests/transform/preprocessing/test_modified_stl_residual.py
+++ b/tests/transform/preprocessing/test_modified_stl_residual.py
@@ -121,3 +121,27 @@ def test_modified_stl_residual_fit_transform_partial_does_not_double_append(monk
 
     assert residual == 3.0
     assert np.array_equal(seen_windows[0], np.array([1.0, 2.0, 3.0, 3.0]))
+
+
+def test_modified_stl_residual_fit_transform_cold_starts_until_enough_values(monkeypatch):
+    import numpy as np
+    from pysad.transform.preprocessing import ModifiedSTLResidualTransformer
+
+    seen_windows = []
+
+    def fake_transform_window(self, X):
+        seen_windows.append(np.asarray(X, dtype=float).copy())
+        return np.asarray(X, dtype=float)
+
+    monkeypatch.setattr(
+        "pysad.transform.preprocessing.modified_stl_residual."
+        "ModifiedSTLResidualTransformer.transform_window",
+        fake_transform_window,
+    )
+
+    transformer = ModifiedSTLResidualTransformer(period=2, window_size=4)
+    residuals = transformer.fit_transform(np.array([[1.0], [2.0], [3.0], [4.0]]))
+
+    assert np.array_equal(residuals.ravel(), np.array([0.0, 0.0, 0.0, 4.0]))
+    assert len(seen_windows) == 1
+    assert np.array_equal(seen_windows[0], np.array([1.0, 2.0, 3.0, 4.0]))

--- a/tests/transform/preprocessing/test_seasonal_trend_decomposer.py
+++ b/tests/transform/preprocessing/test_seasonal_trend_decomposer.py
@@ -1,0 +1,37 @@
+
+def test_seasonal_trend_decomposer_removes_repeating_pattern():
+    import numpy as np
+    from pysad.transform.preprocessing import SeasonalTrendDecomposer
+
+    pattern = np.array([1.0, 2.0, 3.0])
+    X = np.tile(pattern, 8).reshape(-1, 1)
+
+    decomposer = SeasonalTrendDecomposer(season_length=3)
+    residuals = decomposer.fit_transform(X)
+
+    assert residuals.shape == X.shape
+    assert np.all(np.isfinite(residuals))
+    assert np.all(np.isclose(residuals[-6:], 0.0))
+
+
+def test_seasonal_trend_decomposer_transform_uses_fitted_state():
+    import numpy as np
+    from pysad.transform.preprocessing import SeasonalTrendDecomposer
+
+    X = np.tile(np.array([1.0, 2.0, 3.0]), 8).reshape(-1, 1)
+    decomposer = SeasonalTrendDecomposer(season_length=3).fit(X)
+
+    residual = decomposer.transform_partial(np.array([1.0]))
+
+    assert np.all(np.isclose(residual, 0.0))
+
+
+def test_seasonal_trend_decomposer_validates_windows():
+    from numpy.testing import assert_raises
+    from pysad.transform.preprocessing import SeasonalTrendDecomposer
+
+    with assert_raises(ValueError):
+        SeasonalTrendDecomposer(season_length=0)
+
+    with assert_raises(ValueError):
+        SeasonalTrendDecomposer(season_length=3, trend_window=0)


### PR DESCRIPTION
## Summary
- add `ModifiedSTLResidualTransformer`, which owns the paper residual step: STL seasonal component plus `X - seasonal - median(X)`
- add `SeasonalESD`, which maps to the paper's S-ESD method: modified-STL residuals plus generalized ESD with mean/std-dev
- add `SeasonalHybridESD`, which maps to the paper's S-H-ESD method: the same modified-STL residuals plus generalized ESD using median/MAD scale
- validate `SeasonalESD`/`ModifiedSTLResidualTransformer` inputs up front so unsupported `period`/`window_size` combinations fail early
- make `ModifiedSTLResidualTransformer.fit()` compatible with PySAD's `BaseTransformer.fit()` tuple input shape
- clarify that `StandardAbsoluteDeviation` is only a streaming standard-deviation score component, not S-ESD
- clarify that `MedianAbsoluteDeviation` is only a streaming MAD score component, not S-H-ESD
- keep `SeasonalTrendDecomposer` documented as a lightweight online approximation, not the paper's modified-STL implementation
- export the new models/transformer, document them in the API reference, add `statsmodels` as the STL dependency, and add focused tests

Closes #34.
Refs #30.