### PR TITLE
chore: upgrade pyod to 3.5.2 and remove gitter badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,10 +16,6 @@ Python Streaming Anomaly Detection (PySAD)
    :target: https://pysad.readthedocs.io/en/latest/?badge=latest
    :alt: Documentation status
 
-.. image:: https://badges.gitter.im/selimfirat-pysad/community.svg
-   :target: https://gitter.im/selimfirat-pysad/community?utm_source=share-link&utm_medium=link&utm_campaign=share-link
-   :alt: Gitter
-
 .. image:: https://dev.azure.com/selimfirat/pysad/_apis/build/status/selimfirat.pysad?branchName=master
    :target: https://dev.azure.com/selimfirat/pysad/_build/latest?definitionId=2&branchName=master
    :alt: Azure Pipelines Build Status
@@ -123,7 +119,7 @@ Alternatively, you can install the library directly using the source code in Git
 * numpy: 2.1.3
 * scikit-learn: 1.5.2
 * scipy: 1.15.3
-* pyod: 2.1.0
+* pyod: 3.5.2
 * combo: 0.1.3
 
 **Optional Dependencies:**

--- a/docs/badges.rst
+++ b/docs/badges.rst
@@ -13,10 +13,6 @@ Python Streaming Anomaly Detection (PySAD)
    :target: https://pysad.readthedocs.io/en/latest/?badge=latest
    :alt: Documentation status
 
-.. image:: https://badges.gitter.im/selimfirat-pysad/community.svg
-   :target: https://gitter.im/selimfirat-pysad/community?utm_source=share-link&utm_medium=link&utm_campaign=share-link
-   :alt: Gitter
-
 .. image:: https://dev.azure.com/selimfirat/pysad/_apis/build/status/selimfirat.pysad?branchName=master
    :target: https://dev.azure.com/selimfirat/pysad/_build/latest?definitionId=2&branchName=master
    :alt: Azure Pipelines Build Status

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -26,7 +26,7 @@ Alternatively, you can install the library directly using the source code in Git
 * numpy: 2.1.3
 * scikit-learn: 1.5.2
 * scipy: 1.15.3
-* pyod: 2.1.0
+* pyod: 3.5.2
 * combo: 0.1.3
 
 **Optional Dependencies:**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
   "numpy",
   "scikit-learn",
   "scipy",
-  "pyod==2.0.5",
+  "pyod==3.5.2",
   "combo==0.1.3",
 ]
 requires-python = ">=3.10"

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,7 +1,7 @@
 numpy==2.1.3
 scikit-learn==1.5.2
 scipy==1.15.3
-pyod==2.0.5
+pyod==3.5.2
 pandas==2.2.3
 rrcf==0.4.4
 PyNomaly==0.3.5

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,7 +9,7 @@ sphinxcontrib-bibtex==2.6.3
 numpy==2.1.3
 pandas==2.2.3
 scipy==1.15.3
-pyod==2.0.5
+pyod==3.5.2
 rrcf==0.4.4
 PyNomaly==0.3.5
 mmh3==2.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy==2.1.3
 scikit-learn==1.5.2
 scipy==1.15.3
-pyod==2.1.0
+pyod==3.5.2
 combo==0.1.3


### PR DESCRIPTION
This PR upgrades the PyOD dependency to version 3.5.2 (the latest available on PyPI) across all requirements files and documentation, and removes the deprecated Gitter community badge.