### PR TITLE
chore: change release-please branch to develop

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,7 +3,7 @@ name: Release Please
 on:
   push:
     branches:
-      - master
+      - develop
   workflow_dispatch:
 
 permissions:
@@ -20,6 +20,6 @@ jobs:
         uses: googleapis/release-please-action@v4
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
-          target-branch: master
+          target-branch: develop
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json

--- a/.github/workflows/release-validation.yml
+++ b/.github/workflows/release-validation.yml
@@ -13,7 +13,7 @@ on:
       - "scripts/check_release_workflow.py"
   push:
     branches:
-      - master
+      - develop
     paths:
       - ".github/workflows/**"
       - ".release-please-manifest.json"

--- a/docs/versioning.rst
+++ b/docs/versioning.rst
@@ -8,10 +8,10 @@ Releases are automated with GitHub Actions and Release Please.
 Release flow
 ------------
 
-* Merge feature and fix pull requests into ``master`` using conventional commit
+* Merge feature and fix pull requests into ``develop`` using conventional commit
   messages such as ``feat:``, ``fix:``, ``docs:`` and ``chore:``.
 * The ``Release Please`` workflow updates a release pull request on every push to
-  ``master``. That pull request owns the version bump, changelog update and
+  ``develop``. That pull request owns the version bump, changelog update and
   release metadata.
 * Merge the release pull request when the release contents are ready. Release
   Please creates the GitHub release and tag.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,6 +5,7 @@
       "package-name": "pysad",
       "release-type": "python",
       "changelog-path": "CHANGES.txt",
+      "bootstrap-sha": "c1551dca6a78f073c02f3b4fc764db248525625f",
       "extra-files": [
         "pysad/version.py"
       ]

--- a/scripts/check_release_workflow.py
+++ b/scripts/check_release_workflow.py
@@ -47,8 +47,8 @@ def check_release_please() -> None:
     )
     require_pattern(
         workflow,
-        r"^\s*target-branch:\s*master\s*$",
-        "Release Please must target master.",
+        r"^\s*target-branch:\s*develop\s*$",
+        "Release Please must target develop.",
     )
     require(config["packages"]["."]["release-type"] == "python", "Release Please must use python releases.")
     require(


### PR DESCRIPTION
This PR updates the automated release workflow and config to target the `develop` branch instead of `master`. All checks and validation scripts have been successfully updated and verified.