### PR TITLE
docs: comprehensive documentation improvements and warning fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,13 +59,13 @@ Features
 Online Anomaly Detection
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-`PySAD` provides methods for online/sequential anomaly detection, i.e. anomaly detection on streaming data, where model updates itself as a new instance arrives.
+`PySAD` provides methods for online/sequential anomaly detection, i.e. anomaly detection on streaming data, where the model updates itself as a new instance arrives.
 
 
 Resource-Efficient
 ^^^^^^^^^^^^^^^^^^
 
-Streaming methods efficiently handle the limitied memory and processing time requirements of the data streams so that they can be used in near real-time. The methods can only store an instance or a small window of recent instances.
+Streaming methods efficiently handle the limited memory and processing time requirements of the data streams so that they can be used in near real-time. The methods can only store an instance or a small window of recent instances.
 
 
 Complete

--- a/README_template.rst
+++ b/README_template.rst
@@ -47,7 +47,10 @@ Contributors
 
 We thank all our contributors for their valuable input and efforts to make PySAD better!
 
-.. include:: docs/versioning.rst
+Versioning
+==========
+
+`Semantic versioning <http://semver.org/>`_ is used for this project.
 
 .. include:: docs/license.rst
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -25,11 +25,11 @@ For any questions, you may open issue on Github or drop me an email at `yilmasel
 Pull Request Checklist
 ^^^^^^^^^^^^^^^^^^^^^^
 
-* Does features/fixes by your pull request matches the aim of this framework?
+* Do the features/fixes in your pull request match the aim of this framework?
 * Does your code obey PEP8 principles? You may check via `bash lint.sh`.
-* Does your submission passes tests, Travis CI?
+* Does your submission pass all tests (including CI)?
 * Have you checked the active `pull requests <https://github.com/selimfirat/pysad/pulls>`_ and `issues <https://github.com/selimfirat/pysad/issues>`_ so that your contribution does not overlap significantly with these?
-* **For new features** Have you implemented tests so that your new code has more than 95% test coverage and the tests are reasonable?.
+* **For new features** Have you implemented tests so that your new code has more than 95% test coverage and the tests are reasonable?
 * **For new features** Have you implemented examples demonstrating the usage of your new feature?
 
 Development Instructions

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -4,10 +4,10 @@ Frequently Asked Questions
 Can I use stream anomaly models for batch anomaly detection tasks?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The stream anomaly detection models can be used for batch anomaly detection tasks. Yet, the models are mainly designed for the tasks when a model sees an instance only once and removes from memory. Since models cannot always access all data, their performance may suffer. However, they are better fit to real-world problems when data arrives as time passes. You may also see `PyOD library <https://pyod.readthedocs.io/en/latest/>`_ for batch learning models.
+The stream anomaly detection models can be used for batch anomaly detection tasks. Yet, the models are mainly designed for the tasks when a model sees an instance only once and removes from memory. Since models cannot always access all data, their performance may suffer. However, they are a better fit for real-world problems when data arrives as time passes. You may also refer to the `PyOD library <https://pyod.readthedocs.io/en/latest/>`_ for batch learning models.
 
-Can I use batch learning model for stream learning tasks?
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Can I use batch learning models for stream learning tasks?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Batch anomaly detection models from `PyOD library <https://pyod.readthedocs.io/en/latest/>`_ can be used by reference windowing via :class:`pysad.models.reference_window_model` or fitting to initial instances via :class:`pysad.models.one_fit_model`. An example of integration is provided in `Github <https://github.com/selimfirat/pysad/blob/master/examples/example_pyod_integration.py>`_.
 
@@ -19,4 +19,4 @@ Please see :ref:`contributing` for details.
 I found a bug. What should I do?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-You may contribute to this framework by sharing these bugs or feature ideas for improvements. You should open an issue on our `Github repository <https://github.com/selimfirat/pysad>`_. You are also welcome to contribute via opening a pull request. Please see :ref:`contributing` for more information.
+You can contribute to this framework by reporting bugs or sharing ideas for improvements. Please open an issue on our `GitHub repository <https://github.com/selimfirat/pysad>`_. You are also welcome to contribute by opening a pull request. See :ref:`contributing` for more information.

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -4,13 +4,13 @@ Features
 Online Anomaly Detection
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-`PySAD` provides methods for online/sequential anomaly detection, i.e. anomaly detection on streaming data, where model updates itself as a new instance arrives.
+`PySAD` provides methods for online/sequential anomaly detection, i.e. anomaly detection on streaming data, where the model updates itself as a new instance arrives.
 
 
 Resource-Efficient
 ^^^^^^^^^^^^^^^^^^
 
-Streaming methods efficiently handle the limitied memory and processing time requirements of the data streams so that they can be used in near real-time. The methods can only store an instance or a small window of recent instances.
+Streaming methods efficiently handle the limited memory and processing time requirements of the data streams so that they can be used in near real-time. The methods can only store an instance or a small window of recent instances.
 
 
 Complete

--- a/pysad/core/base_model.py
+++ b/pysad/core/base_model.py
@@ -60,7 +60,7 @@ class BaseModel(ABC):
         return self
 
     def score(self, X):
-        """Scores all instaces via score_partial iteratively.
+        """Scores all instances via score_partial iteratively.
 
         Args:
             X (np.float64 array of shape (num_instances, num_features)): The instances in order to score.

--- a/pysad/models/exact_storm.py
+++ b/pysad/models/exact_storm.py
@@ -5,7 +5,7 @@ from pysad.utils.window import Window
 
 
 class ExactStorm(BaseModel):
-    """The Exact-STORM method :cite:`angiulli2007detecting`. This method assigns anomaly score that is the mean of distances to the instances in window of length `window_size` with distnaces less than `max_radius`. Note that the decision making in :cite:`angiulli2007detecting` is not implemented.
+    """The Exact-STORM method :cite:`angiulli2007detecting`. This method assigns anomaly score that is the mean of distances to the instances in window of length `window_size` with distances less than `max_radius`. Note that the decision making in :cite:`angiulli2007detecting` is not implemented.
 
             Args:
                 window_size : int (Default=10000)

--- a/pysad/models/relative_entropy.py
+++ b/pysad/models/relative_entropy.py
@@ -93,14 +93,14 @@ class RelativeEntropy(BaseModel):
         score = 0.0
 
         if len(self.util) >= self.W and self.m > 0 and self.P_hat is not None:
-            score = self._get_aggreement_hypothesis(self.P_hat)
+            score = self._get_agreement_hypothesis(self.P_hat)
 
         return score
 
-    def _get_aggreement_hypothesis(self, P_hat):
+    def _get_agreement_hypothesis(self, P_hat):
         """This function computes multinomial goodness-of-fit test. It calculates
         the relative entropy test statistic between P_hat and all `m` null
-        hypothesis and compares it against the threshold `T` based on cdf of
+        hypotheses and compares it against the threshold `T` based on cdf of
         chi-squared distribution. The test relies on the observation that if the
         null hypothesis P is true, then as the number of samples grow the relative
         entropy converges to a chi-squared distribution1 with K-1 degrees of

--- a/pysad/models/rs_hash.py
+++ b/pysad/models/rs_hash.py
@@ -96,7 +96,7 @@ class RSHash(BaseModel):
         return self
 
     def score_partial(self, X):
-        """Scores the anomalousness of the next instance. Outputs the last score. Note that this method must be called after the fit_partial
+        """Scores the anomalousness of the next instance. Outputs the last score. Note that this method must be called after fit_partial is called.
 
         Args:
             X (any): Ignored.

--- a/pysad/utils/__init__.py
+++ b/pysad/utils/__init__.py
@@ -1,5 +1,5 @@
 """
-The :mod:`pysad.utils` module includes utility functions used in the `PySAD` framework, which can also be useful streaming learning.
+The :mod:`pysad.utils` module includes utility functions used in the `PySAD` framework, which can also be useful for streaming learning.
 """
 from .array_streamer import ArrayStreamer
 import random
@@ -40,7 +40,7 @@ def get_minmax_scalar(x):
     """Utility method that returns the boundaries of the input array.
 
     Args:
-        X (np.float64 array of any shape): Input array.
+        x (np.float64 array of any shape): Input array.
     Returns:
         float: Minimum value in array.
         float: Maximum value in array.


### PR DESCRIPTION
## Summary
This Pull Request introduces a comprehensive set of documentation improvements across the PySAD project, fixing spelling/grammar typos, inlining missing template contents, and resolving all Sphinx build warnings to compile a flawless set of HTML documentation.

### Changes Made
1. **Grammar & Spelling Corrections**:
   - Corrected multiple PR checklist grammatical errors in `docs/contributing.rst`.
   - Polished phrasings and styling in `docs/faq.rst`.
   - Fixed spelling typo `"limitied"` -> `"limited"` in `docs/features.rst`.
   - Fixed spelling typo `"distnaces"` -> `"distances"` in `pysad/models/exact_storm.py`.
   - Fixed spelling typo `"instaces"` -> `"instances"` in `pysad/core/base_model.py`.
   - Fixed module description phrasing typo `"useful streaming learning"` -> `"useful for streaming learning"` and parameter casing discrepancy in `pysad/utils/__init__.py`.
   - Corrected phrasing typo `"must be called after the fit_partial"` -> `"must be called after fit_partial is called."` in `pysad/models/rs_hash.py`.
   - Renamed internal helper function `_get_aggreement_hypothesis` -> `_get_agreement_hypothesis` to fix the spelling typo `"aggreement"` -> `"agreement"`, and fixed grammatical pluralization in comment block.

2. **Sphinx Build Warnings Resolved**:
   - Created the missing `docs/_static` directory to resolve the build warning `WARNING: html_static_path entry '_static' does not exist`.
   - Dynamically matched underline carets to the updated batch-learning header length in `docs/faq.rst` to resolve the short title underline warning.

3. **Template & Compiled README Sync**:
   - Repaired `README_template.rst` which had been trying to include a deleted `docs/versioning.rst` file by replacing it with simple, correct versioning info directly inline.
   - Successfully compiled the root `README.rst` using `python _build_readme.py`.

### Verification Results
- **Sphinx Doc Build (`build_docs.sh`)**: The Sphinx documentation compiles flawlessly with **zero warnings**.
- **Pytest Suite (`pytest`)**: All 144 unit tests run and pass successfully.